### PR TITLE
allow later versions of gymnasium and temporarily remove `MultiEnvRecordVideo`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
    "numpy",
    "graphviz",
    "pyperplan",
-   "gymnasium[classic-control]==0.29.1",
+   "gymnasium[classic-control]>=0.29.1",
    "moviepy",
    "torch"
 ]


### PR DESCRIPTION
@Jaraxxus-Me it turns out that pinning an earlier version of gymnasium leads to breaking changes in other repositories that use this one. also, `MultiEnvRecordVideo` depends on gymnasium 0.29.1 right now and I couldn't figure out an immediate figure to make it forward compatible. sorry to remove your code here, but when you have time, can you figure out how to add `MultiEnvRecordVideo` back in a way that works with both older and newer versions of gymnasium? thanks and sorry that I didn't catch this during review!